### PR TITLE
Allow NJS compiled with pcre2 to handle surrogate code points in regu…

### DIFF
--- a/external/njs_regex.c
+++ b/external/njs_regex.c
@@ -222,6 +222,8 @@ njs_regex_compile(njs_regex_t *regex, u_char *source, size_t len,
          options |= PCRE2_UTF;
     }
 
+    pcre2_set_compile_extra_options(cctx, PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES);
+
     regex->code = pcre2_compile(source, len, options, &ret, &erroff, cctx);
 
     if (njs_slow_path(regex->code == NULL)) {


### PR DESCRIPTION
…lar expressions

Since Javascript uses UTF-16 to encode strings, it is assumed that
[surrogate code points](https://dmitripavlutin.com/what-every-javascript-developer-should-know-about-unicode/#24-surrogate-pairs)
will be valid regex input.  Some libraries including common polyfills and
transpiler plugins use such regular expressions.

By default, pcre2 does not allow code points in these ranges, failing
with `disallowed Unicode code point`.  In order to allow pcre2
to work with these code points, the `PCRE2_EXTRA_ALLOW_SURROGATE_ESCAPES`
option must be set using [pcre2_set_compile_extra_options](https://www.pcre.org/current/doc/html/pcre2_set_compile_extra_options.html).

This change sets this configuration in `pcre2_compile()` if NJS is using pcre2.